### PR TITLE
Rework of encrypt.sh

### DIFF
--- a/encrypt.sh
+++ b/encrypt.sh
@@ -1,9 +1,26 @@
 #!/bin/bash
-KB=$(keybase id 3>&1 1>&2- 2>&3- | grep -o 'Identifying .*$' | sed 's/Identifying \(.*\)/\1/' | gsed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" )
-printf 'What user is this to?: '
-read -r KBUSER
-echo ''
-echo "Your Message(End with Ctrl-D): "
+
+echo '*** Keybase Messaging Tool ***'
+
+LIST=($(keybase list-following))
+ID=$(keybase status | awk '/Default user:/ {print $3}')
+TOTAL=${#LIST[@]}
+COUNT=1
+USER=0
+
+for following in ${LIST[@]}; do
+  echo "($COUNT) $following"
+  ((COUNT+=1))
+done
+
+until [[ "$USER" -ge 1 && "$USER" -le "$TOTAL" ]]; do
+  echo 'What user are we conversing with today?'
+  read -p '> ' USER
+done
+
+KBUSER=${LIST[(($USER-1))]}
+
+echo "Your Message (Ctrl-D to end): "
 input=$(cat)
 
-echo $input | keybase $1 encrypt $KBUSER > /keybase/private/$KB,$KBUSER/$(perl -e 'print(time());')
+echo $input | keybase $1 encrypt $KBUSER > /keybase/private/$ID,$KBUSER/$(perl -e 'print(time());')


### PR DESCRIPTION
The proposed changes clean up the script for readability purposes. It also removes the need for gsed/sed as it uses "keybase status" w/ awk. It will list out users you are following and allow you to message that user w/ a corresponding number rather than typing out a name.